### PR TITLE
Add simple journal rankings website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # Ashish
 Test Repo
+
+## Journal Rankings Website
+
+A simple static website is provided in the `website` directory. It includes JSON files containing sample ABS and ABDC journal listings and a single-page application to switch between them.
+
+Open `website/index.html` in a browser to use the site.

--- a/website/data/abdc.json
+++ b/website/data/abdc.json
@@ -1,0 +1,7 @@
+[
+  {"journal": "Journal of Marketing", "ranking": "A"},
+  {"journal": "Information Systems Research", "ranking": "A*"},
+  {"journal": "Journal of Accounting", "ranking": "B"},
+  {"journal": "Finance Review", "ranking": "A"},
+  {"journal": "International Business Journal", "ranking": "A"}
+]

--- a/website/data/abs.json
+++ b/website/data/abs.json
@@ -1,0 +1,7 @@
+[
+  {"journal": "Journal of Economics", "ranking": "ABS3"},
+  {"journal": "Management Science", "ranking": "ABS4*"},
+  {"journal": "Journal of Finance", "ranking": "ABS4"},
+  {"journal": "Marketing Journal", "ranking": "ABS2"},
+  {"journal": "Operations Research", "ranking": "ABS4"}
+]

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Journal Rankings</title>
+<style>
+  body { font-family: Arial, sans-serif; margin: 20px; }
+  table { border-collapse: collapse; width: 100%; margin-top: 20px; }
+  th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+  th { background-color: #f4f4f4; }
+  .tabs { margin-top: 20px; }
+  .tab { margin-right: 10px; cursor: pointer; color: blue; text-decoration: underline; }
+</style>
+</head>
+<body>
+<h1>Journal Rankings</h1>
+<div class="tabs">
+  <span class="tab" onclick="loadList('abs')">ABS List</span>
+  <span class="tab" onclick="loadList('abdc')">ABDC List</span>
+</div>
+<table id="journal-table">
+  <thead>
+    <tr><th>Journal</th><th>Ranking</th></tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<script>
+async function loadList(type) {
+  const response = await fetch(`data/${type}.json`);
+  const data = await response.json();
+  const tbody = document.querySelector('#journal-table tbody');
+  tbody.innerHTML = '';
+  data.forEach(item => {
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${item.journal}</td><td>${item.ranking}</td>`;
+    tbody.appendChild(row);
+  });
+}
+// Load ABS list by default
+loadList('abs');
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a minimal static website showing ABS and ABDC journals
- document how to open the website

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b2bfc604c832badca30bf2cce3ac8