### PR TITLE
Add demo journal explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# Ashish
-Test Repo
+# Journal Explorer
+
+This project provides a simple demo for browsing journal rankings from the ABS and ABDC lists. It contains a small Node server and a minimal React client loaded via CDN links.
+
+## Running the Demo
+
+1. Start the server:
+   ```bash
+   node server/server.js
+   ```
+   The API will run on `http://localhost:3001`.
+
+2. Open `client/index.html` in a browser. The page will request data from the server and render a table of journals. Use the buttons to switch between ABS and ABDC lists and the search box to filter by title.
+
+## Notes
+
+The dataset is only a placeholder with a few example journals. For a real deployment you would replace `server/data/abs.json` and `server/data/abdc.json` with full datasets and likely use a framework such as Express and a database for storage.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Journal Explorer</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+</head>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <div id="root" class="p-4"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/client/main.js
+++ b/client/main.js
@@ -1,0 +1,59 @@
+const e = React.createElement;
+
+function App() {
+  const [tab, setTab] = React.useState('abs');
+  const [journals, setJournals] = React.useState([]);
+  const [search, setSearch] = React.useState('');
+
+  React.useEffect(() => {
+    fetch(`/api/${tab}`)
+      .then(res => res.json())
+      .then(data => setJournals(data));
+  }, [tab]);
+
+  const filtered = journals.filter(j =>
+    j.title.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    e('div', null,
+      e('div', { className: 'mb-4' },
+        e('button', {
+          className: `mr-2 px-4 py-2 rounded ${tab==='abs'? 'bg-blue-500 text-white':'bg-gray-200'}`,
+          onClick: () => setTab('abs')
+        }, 'ABS'),
+        e('button', {
+          className: `px-4 py-2 rounded ${tab==='abdc'? 'bg-blue-500 text-white':'bg-gray-200'}`,
+          onClick: () => setTab('abdc')
+        }, 'ABDC')
+      ),
+      e('input', {
+        className: 'border p-2 mb-4 w-full text-black',
+        placeholder: 'Search by title',
+        value: search,
+        onChange: e => setSearch(e.target.value)
+      }),
+      e('table', { className: 'min-w-full table-auto border-collapse' },
+        e('thead', null,
+          e('tr', null,
+            ['Title', 'Rank', 'Field', 'Country'].map(h =>
+              e('th', { key: h, className: 'border px-2 py-1' }, h)
+            )
+          )
+        ),
+        e('tbody', null,
+          filtered.map(j =>
+            e('tr', { key: j.issn },
+              e('td', { className: 'border px-2 py-1' }, j.title),
+              e('td', { className: 'border px-2 py-1' }, j.rank),
+              e('td', { className: 'border px-2 py-1' }, j.field),
+              e('td', { className: 'border px-2 py-1' }, j.country)
+            )
+          )
+        )
+      )
+    )
+  );
+}
+
+ReactDOM.render(e(App), document.getElementById('root'));

--- a/server/data/abdc.json
+++ b/server/data/abdc.json
@@ -1,0 +1,20 @@
+[
+  {
+    "title": "Journal of Marketing",
+    "rank": "A*",
+    "field": "Marketing",
+    "country": "USA",
+    "openAccess": false,
+    "publisher": "American Marketing Association",
+    "issn": "0022-2429"
+  },
+  {
+    "title": "Public Administration Review",
+    "rank": "A",
+    "field": "Public Administration",
+    "country": "USA",
+    "openAccess": true,
+    "publisher": "Wiley",
+    "issn": "0033-3352"
+  }
+]

--- a/server/data/abs.json
+++ b/server/data/abs.json
@@ -1,0 +1,20 @@
+[
+  {
+    "title": "Journal of Marketing",
+    "rank": "4*",
+    "field": "Marketing",
+    "country": "USA",
+    "openAccess": false,
+    "publisher": "American Marketing Association",
+    "issn": "0022-2429"
+  },
+  {
+    "title": "Operations Research",
+    "rank": "4",
+    "field": "Operations",
+    "country": "USA",
+    "openAccess": false,
+    "publisher": "INFORMS",
+    "issn": "0030-364X"
+  }
+]

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,31 @@
+const http = require('http');
+const fs = require('fs');
+const url = require('url');
+const path = require('path');
+
+const PORT = process.env.PORT || 3001;
+
+function readData(file) {
+  return JSON.parse(fs.readFileSync(path.join(__dirname, 'data', file)));
+}
+
+function handleRequest(req, res) {
+  const parsedUrl = url.parse(req.url, true);
+  if (parsedUrl.pathname === '/api/abs') {
+    const data = readData('abs.json');
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(data));
+  } else if (parsedUrl.pathname === '/api/abdc') {
+    const data = readData('abdc.json');
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(data));
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+}
+
+const server = http.createServer(handleRequest);
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create placeholder Node server exposing `/api/abs` and `/api/abdc`
- add sample ABS/ABDC journal data
- build minimal React + Tailwind client loaded via CDN
- document demo usage in README

## Testing
- `node server/server.js` (server starts)
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688b2d7092f0832bbb32840822cefd98