### PR TITLE
Add Journal Index Checker prototype: server, SPA client, DB schema, and admin import workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,174 @@
-# Journal Explorer
+# Journal Index Checker (Website Prototype)
 
-This project provides a simple demo for browsing journal rankings from the ABS and ABDC lists. It contains a small Node server and a minimal React client loaded via CDN links.
+A **build-ready responsive website prototype** for research scholars, faculty, and PhD students to check whether a journal appears in ABDC, ABS/AJG, and Scopus source datasets from one place.
 
-## Running the Demo
+> **Accuracy-first principle:** The application never fabricates rankings or indexing status. Missing values are explicitly shown as: **"Not available in verified source data."**
 
-1. Start the server:
-   ```bash
-   node server/server.js
-   ```
-   The API will run on `http://localhost:3001`.
+---
 
-2. Open `client/index.html` in a browser. The page will request data from the server and render a table of journals. Use the buttons to switch between ABS and ABDC lists and the search box to filter by title.
+## 1) Chosen tech stack (and why)
 
-## Notes
+- **Frontend:** Vanilla JavaScript + HTML + CSS (single-page routed website)
+  - Lightweight, easy to maintain, no heavy framework setup required for prototype delivery.
+- **Backend:** Node.js + Express
+  - Clean API endpoints for search, detail, compare, admin upload/import, rollback, and logs.
+- **Database:** SQLite (`sqlite3`)
+  - Practical local relational database for source-traceable entries and import logs.
+- **File import:** `multer` + `xlsx`
+  - Supports both CSV and XLSX import workflows.
+- **Caching:** `node-cache`
+  - In-memory caching for repeated search queries.
 
-The dataset is only a placeholder with a few example journals. For a real deployment you would replace `server/data/abs.json` and `server/data/abdc.json` with full datasets and likely use a framework such as Express and a database for storage.
+---
+
+## 2) Implemented pages
+
+- `/` Home page
+- `#/results` Search results with filters + sorting
+- `#/journal/:id` Journal detail page
+- `#/compare` Side-by-side comparison (2–4 journals)
+- `#/saved` Saved shortlist page with CSV export + copy summary
+- `#/admin` Admin dashboard (upload, preview, approve, rollback, logs, rejected queue)
+- `#/about` Methodology + limitations + disclaimer
+
+---
+
+## 3) Data model (SQLite)
+
+Implemented tables:
+
+- `journals_master`
+- `abdc_entries`
+- `abs_entries`
+- `scopus_entries`
+- `import_logs`
+- `review_queue`
+
+Schema file: `server/migrations/schema.sql`
+
+---
+
+## 4) Matching logic
+
+The system uses this strict priority:
+
+1. ISSN exact match
+2. eISSN exact match
+3. normalized exact title match
+4. controlled fuzzy title match (Levenshtein-based score)
+
+Confidence labels:
+- `Exact match`
+- `Strong probable match`
+- `Uncertain match`
+
+Important behavior:
+- Source datasets remain separate (no blind merging).
+- If a source does not contain a value, the UI shows explicit not-available text.
+- Ambiguous import rows are routed to `review_queue` for manual admin review.
+
+---
+
+## 5) Admin workflow
+
+1. Open `#/admin`
+2. Save admin token in browser (localStorage)
+3. Upload CSV/XLSX for `abdc` / `abs` / `scopus`
+4. Preview:
+   - row sample
+   - auto header mapping
+   - duplicate count
+   - rejected rows
+5. Approve import
+6. Review logs + review queue
+7. Rollback the last completed import per source
+
+Admin endpoints require header:
+
+`x-admin-token: <ADMIN_TOKEN>`
+
+Default token for local prototype: `change-me-admin-token` (set env var in production).
+
+---
+
+## 6) Optional AI helper (database-grounded)
+
+Endpoint: `POST /api/assistant/query`
+
+Example query strings:
+- "Show ABDC A journals in operations that are also indexed in Scopus"
+- "Find ABS 3 journals"
+
+The response is strictly constrained to uploaded DB data. If no data exists, API returns:
+- **"Not available in uploaded verified source data."**
+
+---
+
+## 7) Seed data and templates
+
+- **DEMO ONLY seed:** `server/data/demo_seed.json`
+- Import templates:
+  - `server/data/templates/abdc_template.csv`
+  - `server/data/templates/abs_template.csv`
+  - `server/data/templates/scopus_template.csv`
+
+---
+
+## 8) Run locally
+
+```bash
+npm install
+npm run init-db
+npm start
+```
+
+Then open:
+
+- Website: `http://localhost:3001`
+- Health check: `http://localhost:3001/api/health`
+
+---
+
+## 9) Deployment steps
+
+1. Provision Linux VM/container with Node 18+.
+2. Copy project files.
+3. Install deps: `npm install --omit=dev`
+4. Set env vars:
+   - `PORT` (e.g., `3001`)
+   - `ADMIN_TOKEN` (strong secret)
+5. Initialize DB once: `npm run init-db`
+6. Start service: `npm start`
+7. Put Nginx/Caddy reverse proxy in front with HTTPS.
+8. Back up `server/db/journal_index_checker.sqlite` regularly.
+
+---
+
+## 10) Updating datasets in future
+
+1. Go to `#/admin` with admin token.
+2. Upload new ABDC/ABS/Scopus file (CSV/XLSX).
+3. Preview mappings and duplicates.
+4. Approve import.
+5. Download the import error report and clear review queue items.
+6. If the import is incorrect, rollback the last import for that source.
+
+---
+
+## 11) Project structure
+
+- `client/` responsive website UI (pages, routing, compare, shortlist, admin UI)
+- `server/server.js` API and import workflow
+- `server/db/` SQLite connection layer
+- `server/migrations/` schema definition
+- `server/utils/` normalization + fuzzy scoring helpers
+- `server/data/` demo seed and import templates
+
+---
+
+## 12) Accuracy and disclaimer controls
+
+- Homepage and journal detail page include visible guidance disclaimer.
+- Missing values are not guessed.
+- Source-specific verified date and source links are displayed where available.
+- Public users have read-only search; admin-only endpoints are protected by token.

--- a/client/assets/styles.css
+++ b/client/assets/styles.css
@@ -1,0 +1,45 @@
+:root {
+  --bg: #f4f6f8;
+  --surface: #ffffff;
+  --text: #1d2a33;
+  --muted: #4f6470;
+  --primary: #1b4d6b;
+  --border: #d8dfe5;
+}
+* { box-sizing: border-box; }
+body { margin: 0; font-family: Inter, Arial, sans-serif; background: var(--bg); color: var(--text); }
+.container { max-width: 1100px; margin: 0 auto; padding: 1rem; }
+.topbar { background: #102b3a; color: #fff; position: sticky; top: 0; z-index: 10; }
+.nav-wrap { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.nav-links { display: flex; gap: 0.8rem; flex-wrap: wrap; }
+.nav-links a { color: #d9e7f0; text-decoration: none; font-size: 0.92rem; }
+.nav-links a:hover { color: #fff; }
+.card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1rem; margin: 0.8rem 0; }
+.grid { display: grid; gap: 1rem; }
+.grid.two { grid-template-columns: 2fr 1fr; }
+.grid.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+label { font-weight: 600; font-size: 0.9rem; display: block; margin-bottom: 0.3rem; }
+input, select, button, textarea { width: 100%; padding: 0.6rem; border-radius: 8px; border: 1px solid var(--border); font: inherit; }
+button { background: var(--primary); color: #fff; border: none; cursor: pointer; }
+button.secondary { background: #516a7a; }
+button.ghost { background: #ebf1f5; color: #23313b; border: 1px solid #c7d5df; }
+.badge { display: inline-block; padding: 0.2rem 0.5rem; border-radius: 999px; font-size: 0.72rem; margin-right: 0.3rem; }
+.badge.abdc { background: #ffe6b8; }
+.badge.abs { background: #d8f3dc; }
+.badge.scopus { background: #d6e7ff; }
+.badge.warn { background: #fde2e4; }
+.disclaimer { border-left: 5px solid #cc7a00; background: #fff8eb; font-size: 0.92rem; }
+.small { font-size: 0.85rem; color: var(--muted); }
+.result-row { display: grid; grid-template-columns: 1.6fr repeat(4, 1fr); gap: 0.5rem; align-items: center; border-top: 1px solid var(--border); padding: 0.65rem 0; }
+.result-row.header { font-weight: 700; border-top: 0; }
+.table-wrap { overflow-x: auto; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid var(--border); padding: 0.5rem; text-align: left; vertical-align: top; }
+.highlight { background: #f2f8fb; }
+#toggle-filters { display: none; margin-bottom: 0.8rem; }
+@media (max-width: 900px) {
+  .grid.two, .grid.three { grid-template-columns: 1fr; }
+  .result-row { grid-template-columns: 1fr; }
+  #toggle-filters { display: block; }
+  #filter-panel { display: none; }
+}

--- a/client/index.html
+++ b/client/index.html
@@ -3,13 +3,32 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Journal Explorer</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <title>Journal Index Checker</title>
+  <link rel="stylesheet" href="/assets/styles.css" />
 </head>
-<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-  <div id="root" class="p-4"></div>
-  <script src="main.js"></script>
+<body>
+  <header class="topbar">
+    <div class="container nav-wrap">
+      <h1>Journal Index Checker</h1>
+      <nav class="nav-links">
+        <a href="#/">Home</a>
+        <a href="#/results">Search</a>
+        <a href="#/compare">Compare</a>
+        <a href="#/saved">Saved</a>
+        <a href="#/about">Methodology</a>
+        <a href="#/admin">Admin</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container" id="app"></main>
+
+  <template id="disclaimer-template">
+    <section class="card disclaimer">
+      <strong>Guidance Disclaimer:</strong> This tool is for guidance only. Always verify final journal ranking/indexing from official ABDC, ABS/AJG, Scopus (or equivalent official) sources before submission decisions.
+    </section>
+  </template>
+
+  <script src="/main.js"></script>
 </body>
 </html>

--- a/client/main.js
+++ b/client/main.js
@@ -1,59 +1,472 @@
-const e = React.createElement;
+const app = document.getElementById('app');
+const API = '';
+const NA = 'Not available in verified source data.';
+const NOT_FOUND = 'Not found in uploaded verified source data.';
+const savedKey = 'journal-index-checker-saved';
+const adminTokenKey = 'journal-index-checker-admin-token';
+const recentSearchesKey = 'journal-index-checker-recent-searches';
 
-function App() {
-  const [tab, setTab] = React.useState('abs');
-  const [journals, setJournals] = React.useState([]);
-  const [search, setSearch] = React.useState('');
+const state = {
+  results: [],
+  filters: {},
+};
 
-  React.useEffect(() => {
-    fetch(`/api/${tab}`)
-      .then(res => res.json())
-      .then(data => setJournals(data));
-  }, [tab]);
-
-  const filtered = journals.filter(j =>
-    j.title.toLowerCase().includes(search.toLowerCase())
-  );
-
-  return (
-    e('div', null,
-      e('div', { className: 'mb-4' },
-        e('button', {
-          className: `mr-2 px-4 py-2 rounded ${tab==='abs'? 'bg-blue-500 text-white':'bg-gray-200'}`,
-          onClick: () => setTab('abs')
-        }, 'ABS'),
-        e('button', {
-          className: `px-4 py-2 rounded ${tab==='abdc'? 'bg-blue-500 text-white':'bg-gray-200'}`,
-          onClick: () => setTab('abdc')
-        }, 'ABDC')
-      ),
-      e('input', {
-        className: 'border p-2 mb-4 w-full text-black',
-        placeholder: 'Search by title',
-        value: search,
-        onChange: e => setSearch(e.target.value)
-      }),
-      e('table', { className: 'min-w-full table-auto border-collapse' },
-        e('thead', null,
-          e('tr', null,
-            ['Title', 'Rank', 'Field', 'Country'].map(h =>
-              e('th', { key: h, className: 'border px-2 py-1' }, h)
-            )
-          )
-        ),
-        e('tbody', null,
-          filtered.map(j =>
-            e('tr', { key: j.issn },
-              e('td', { className: 'border px-2 py-1' }, j.title),
-              e('td', { className: 'border px-2 py-1' }, j.rank),
-              e('td', { className: 'border px-2 py-1' }, j.field),
-              e('td', { className: 'border px-2 py-1' }, j.country)
-            )
-          )
-        )
-      )
-    )
-  );
+function getSaved() {
+  return JSON.parse(localStorage.getItem(savedKey) || '[]');
 }
 
-ReactDOM.render(e(App), document.getElementById('root'));
+function setSaved(value) {
+  localStorage.setItem(savedKey, JSON.stringify(value));
+}
+
+function disclaimerHtml() {
+  return document.getElementById('disclaimer-template').innerHTML;
+}
+
+function pageShell(content, includeDisclaimer = true) {
+  return `${content}${includeDisclaimer ? disclaimerHtml() : ''}`;
+}
+
+function pushRecentSearch(query) {
+  if (!query) return;
+  const existing = JSON.parse(localStorage.getItem(recentSearchesKey) || '[]');
+  const updated = [query, ...existing.filter((q) => q !== query)].slice(0, 8);
+  localStorage.setItem(recentSearchesKey, JSON.stringify(updated));
+}
+
+function matchBadge(label) {
+  const css = label === 'Exact match' ? 'abdc' : label === 'Strong probable match' ? 'abs' : 'warn';
+  return `<span class="badge ${css}">${label}</span>`;
+}
+
+async function apiGet(path) {
+  const response = await fetch(`${API}${path}`);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return response.json();
+}
+
+async function apiPost(path, body, admin = false) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (admin) headers['x-admin-token'] = localStorage.getItem(adminTokenKey) || '';
+  const response = await fetch(`${API}${path}`, { method: 'POST', headers, body: JSON.stringify(body) });
+  if (!response.ok) throw new Error(await response.text());
+  return response.json();
+}
+
+function renderHome() {
+  const recent = JSON.parse(localStorage.getItem(recentSearchesKey) || '[]');
+  app.innerHTML = pageShell(`
+    <section class="card">
+      <h2>Unified journal indexing lookup for researchers</h2>
+      <p>Search ABDC, ABS/AJG, and Scopus data from one place using title, ISSN, eISSN, publisher, or subject area.</p>
+      <div class="grid two">
+        <div>
+          <label>Search journal</label>
+          <input id="home-search" placeholder="e.g., Journal of Operations Management / 0272-6963 / Elsevier" />
+          <button id="home-search-btn" style="margin-top: 0.6rem;">Search Now</button>
+          <p class="small">Quick examples: "supply chain", "0925-5273", "Wiley entrepreneurship".</p>
+          ${recent.length ? `<div class="small"><strong>Recent searches:</strong> ${recent.map((r) => `<a href="#/results?q=${encodeURIComponent(r)}">${r}</a>`).join(' | ')}</div>` : ''}
+        </div>
+        <div class="card">
+          <h3>What each source means</h3>
+          <ul>
+            <li><strong>ABDC:</strong> Academic Business Deans Council quality list.</li>
+            <li><strong>ABS/AJG:</strong> Academic Journal Guide rating list.</li>
+            <li><strong>Scopus:</strong> Elsevier indexing database status.</li>
+          </ul>
+          <p class="small">Future-ready architecture supports Web of Science, UGC-CARE, and more.</p>
+        </div>
+      </div>
+    </section>
+  `);
+
+  document.getElementById('home-search-btn').onclick = () => {
+    const q = document.getElementById('home-search').value.trim();
+    location.hash = `#/results?q=${encodeURIComponent(q)}`;
+  };
+}
+
+function resultRowHtml(row) {
+  const incomplete = [row.abdc_rank, row.abs_rating, row.scopus_status].some((v) => v === NOT_FOUND);
+  return `
+    <div class="result-row">
+      <div>
+        <a href="#/journal/${row.id}"><strong>${row.canonical_title}</strong></a>
+        <div class="small">ISSN: ${row.issn || NA} | eISSN: ${row.eissn || NA}</div>
+        <div class="small">Publisher: ${row.publisher || NA} | Subject: ${row.subject_area || NA}</div>
+        <div class="small">Match: ${matchBadge(row.match_confidence)}</div>
+        ${incomplete ? '<div class="small"><span class="badge warn">Incomplete data</span> Verify from source links.</div>' : ''}
+      </div>
+      <div><span class="badge abdc">ABDC</span> ${row.abdc_rank || NA}</div>
+      <div><span class="badge abs">ABS</span> ${row.abs_rating || NA}</div>
+      <div><span class="badge scopus">Scopus</span> ${row.scopus_status || NA}</div>
+      <div>
+        <button class="ghost" data-save="${row.id}">Save</button>
+        <button class="secondary" data-compare="${row.id}" style="margin-top: 0.4rem;">Compare</button>
+      </div>
+    </div>
+  `;
+}
+
+async function renderResults() {
+  const url = new URL(location.href.replace('#/', ''));
+  const q = url.searchParams.get('q') || '';
+  const sortBy = url.searchParams.get('sort_by') || 'relevance';
+
+  app.innerHTML = pageShell(`
+    <section class="grid two">
+      <aside class="card">
+        <button class="ghost" id="toggle-filters">Toggle Filters (mobile)</button>
+        <div id="filter-panel">
+        <h3>Filters</h3>
+        <label>ABDC rank</label>
+        <select id="f-abdc"><option value="">All</option><option>A*</option><option>A</option><option>B</option><option>C</option></select>
+        <label>ABS rating</label>
+        <select id="f-abs"><option value="">All</option><option>4</option><option>3</option><option>2</option><option>1</option></select>
+        <label>Scopus status</label>
+        <select id="f-scopus"><option value="">All</option><option>Indexed</option><option>Not indexed</option></select>
+        <label>Publisher contains</label>
+        <input id="f-publisher" />
+        <label>Subject area contains</label>
+        <input id="f-subject" />
+        <label><input type="checkbox" id="f-exact" style="width:auto;"/> Exact matches only</label>
+        <label><input type="checkbox" id="f-similar" checked style="width:auto;"/> Show similar matches</label>
+        <button id="apply-filters">Apply</button>
+        </div>
+      </aside>
+      <section>
+        <div class="card">
+          <h2>Search Results</h2>
+          <div class="grid three">
+            <div><label>Query</label><input id="q" value="${q}" /></div>
+            <div><label>Sort by</label><select id="sort-by"><option value="relevance">Relevance</option><option value="title">Title</option><option value="abdc_rank">ABDC rank</option><option value="abs_rating">ABS rating</option><option value="publisher">Publisher</option></select></div>
+            <div style="display:flex;align-items:end;"><button id="run-search">Search</button></div>
+          </div>
+          <div id="results-list" class="card" style="margin-top:0.8rem;"><em>Loading results...</em></div>
+        </div>
+      </section>
+    </section>
+  `);
+
+  document.getElementById('sort-by').value = sortBy;
+  await loadResults();
+
+  document.getElementById('run-search').onclick = () => updateSearchHash();
+  document.getElementById('apply-filters').onclick = () => updateSearchHash(true);
+  document.getElementById('toggle-filters').onclick = () => {
+    const panel = document.getElementById('filter-panel');
+    panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+  };
+}
+
+function updateSearchHash(includeFilters = false) {
+  const params = new URLSearchParams();
+  params.set('q', document.getElementById('q').value.trim());
+  params.set('sort_by', document.getElementById('sort-by').value);
+  if (includeFilters) {
+    [['abdc_rank', 'f-abdc'], ['abs_rating', 'f-abs'], ['scopus_status', 'f-scopus'], ['publisher', 'f-publisher'], ['subject_area', 'f-subject']]
+      .forEach(([k, id]) => { const v = document.getElementById(id).value.trim(); if (v) params.set(k, v); });
+    params.set('exact_only', document.getElementById('f-exact').checked ? 'true' : 'false');
+    params.set('show_similar', document.getElementById('f-similar').checked ? 'true' : 'false');
+  }
+  location.hash = `#/results?${params.toString()}`;
+}
+
+async function loadResults() {
+  const url = new URL(location.href.replace('#/', ''));
+  const payload = await apiGet(`/api/search?${url.searchParams.toString()}`);
+  pushRecentSearch(payload.query);
+  state.results = payload.results;
+
+  const list = document.getElementById('results-list');
+  if (!payload.results.length) {
+    list.innerHTML = `<strong>No results.</strong> ${NOT_FOUND}`;
+    return;
+  }
+
+  list.innerHTML = `
+    ${payload.did_you_mean ? `<div class="card"><strong>${payload.did_you_mean.text}</strong> <a href="#/results?q=${encodeURIComponent(payload.did_you_mean.suggestion)}">Search suggestion</a></div>` : ''}
+    <p><strong>${payload.total}</strong> result(s)</p>
+    ${payload.results.map(resultRowHtml).join('')}
+  `;
+  list.querySelectorAll('[data-save]').forEach((button) => {
+    button.onclick = () => {
+      const id = Number(button.dataset.save);
+      const saved = getSaved();
+      if (!saved.includes(id)) setSaved([...saved, id]);
+      alert('Saved to shortlist.');
+    };
+  });
+
+  list.querySelectorAll('[data-compare]').forEach((button) => {
+    button.onclick = () => {
+      const id = Number(button.dataset.compare);
+      const current = new URLSearchParams(location.hash.split('?')[1] || '');
+      const ids = (current.get('compare_ids') || '').split(',').filter(Boolean);
+      if (!ids.includes(String(id)) && ids.length < 4) ids.push(String(id));
+      location.hash = `#/compare?ids=${ids.join(',')}`;
+    };
+  });
+}
+
+function sourceCard(label, entries, fieldMap) {
+  const first = entries[0] || {};
+  if (first.note) return `<section class="card"><h3>${label}</h3><p>${first.note}</p></section>`;
+
+  return `
+    <section class="card">
+      <h3>${label}</h3>
+      ${entries.map((entry) => `
+        <div class="card">
+          <div><strong>Raw source title:</strong> ${entry.source_title || NOT_FOUND}</div>
+          <div><strong>Source verified date:</strong> ${entry.verified_date || NOT_FOUND}</div>
+          ${Object.entries(fieldMap).map(([k, title]) => `<div><strong>${title}:</strong> ${entry[k] || NA}</div>`).join('')}
+        </div>
+      `).join('')}
+    </section>
+  `;
+}
+
+async function renderJournalDetail(id) {
+  const journal = await apiGet(`/api/journals/${id}`);
+  app.innerHTML = pageShell(`
+    <section class="card">
+      <h2>${journal.canonical_title}</h2>
+      ${journal.data_warning ? `<div class="card"><strong>Warning:</strong> ${journal.data_warning}</div>` : ''}
+      <p><strong>Match handling:</strong> ISSN > eISSN > exact title > controlled fuzzy title.</p>
+      <p class="small">${journal.disclaimer}</p>
+      <div class="grid two">
+        <div class="card">
+          <h3>Metadata</h3>
+          <div><strong>ISSN:</strong> ${journal.issn || NA}</div>
+          <div><strong>eISSN:</strong> ${journal.eissn || NA}</div>
+          <div><strong>Publisher:</strong> ${journal.publisher || NA}</div>
+          <div><strong>Subject area:</strong> ${journal.subject_area || NA}</div>
+          <div><strong>Alternate title:</strong> ${journal.alt_titles || NA}</div>
+        </div>
+        <div class="card">
+          <h3>Difference note across sources</h3>
+          <p class="small">Values are displayed exactly as imported per source. Missing values are never inferred.</p>
+          <p class="small">If ISSN/title conflict appears in source upload, check admin review queue for uncertain rows.</p>
+        </div>
+      </div>
+    </section>
+    ${sourceCard('ABDC', journal.sources.abdc, { source_title: 'Source title', abdc_rank: 'ABDC rank', field_code: 'Field code', verified_date: 'Verified date', source_url: 'Source link' })}
+    ${sourceCard('ABS / AJG', journal.sources.abs, { source_title: 'Source title', abs_rating: 'ABS rating', subject_group: 'Subject group', verified_date: 'Verified date', source_url: 'Source link' })}
+    ${sourceCard('Scopus', journal.sources.scopus, { source_title: 'Source title', scopus_status: 'Scopus status', active_or_discontinued: 'Active/discontinued', coverage_note: 'Coverage note', verified_date: 'Verified date', source_url: 'Source link' })}
+  `);
+}
+
+async function renderCompare() {
+  const params = new URLSearchParams(location.hash.split('?')[1] || '');
+  const ids = params.get('ids') || '';
+  if (!ids) {
+    app.innerHTML = '<section class="card"><h2>Compare journals</h2><p>Select 2 to 4 journals from search results first.</p></section>';
+    return;
+  }
+
+  const data = await apiGet(`/api/compare?ids=${ids}`);
+  const fields = ['issn', 'eissn', 'publisher', 'subject_area', 'abdc_rank', 'abs_rating', 'scopus_status', 'active_or_discontinued'];
+  app.innerHTML = pageShell(`
+    <section class="card table-wrap">
+      <h2>Compare Journals</h2>
+      <button id="export-compare-csv" class="secondary">Export comparison as CSV</button>
+      <table>
+        <thead><tr><th>Field</th>${data.journals.map((j) => `<th>${j.canonical_title}</th>`).join('')}</tr></thead>
+        <tbody>
+          ${fields.map((field) => `
+            <tr>
+              <td class="highlight"><strong>${field}</strong></td>
+              ${data.journals.map((j) => `<td class="${(data.journals.some((o) => (o[field] || '') !== (j[field] || '')) && ['abdc_rank', 'abs_rating', 'scopus_status', 'active_or_discontinued'].includes(field)) ? 'highlight' : ''}">${j[field] || NA}</td>`).join('')}
+            </tr>
+          `).join('')}
+        </tbody>
+      </table>
+    </section>
+  `);
+
+  document.getElementById('export-compare-csv').onclick = () => {
+    const rows = [['field', ...data.journals.map((j) => j.canonical_title)]].concat(
+      fields.map((field) => [field, ...data.journals.map((j) => j[field] || '')])
+    );
+    const csv = rows.map((row) => row.map((v) => `"${String(v).replaceAll('"', '""')}"`).join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'journal_comparison.csv';
+    a.click();
+  };
+}
+
+async function renderSaved() {
+  const saved = getSaved();
+  if (!saved.length) {
+    app.innerHTML = '<section class="card"><h2>Saved shortlist</h2><p>No journals saved yet.</p></section>';
+    return;
+  }
+
+  const data = await apiGet(`/api/compare?ids=${saved.join(',')}`);
+  app.innerHTML = pageShell(`
+    <section class="card">
+      <h2>Saved shortlist</h2>
+      <button id="copy-summary" class="secondary">Copy result summary</button>
+      <button id="export-csv" class="ghost" style="margin-top:0.5rem;">Export CSV</button>
+      <div id="saved-list">${data.journals.map((j) => `
+        <div class="card">
+          <strong>${j.canonical_title}</strong>
+          <div class="small">ABDC: ${j.abdc_rank || NA} | ABS: ${j.abs_rating || NA} | Scopus: ${j.scopus_status || NA}</div>
+          <button class="ghost" data-remove="${j.id}" style="margin-top:0.4rem;">Remove</button>
+        </div>
+      `).join('')}</div>
+    </section>
+  `);
+
+  document.querySelectorAll('[data-remove]').forEach((btn) => {
+    btn.onclick = () => {
+      const id = Number(btn.dataset.remove);
+      setSaved(getSaved().filter((x) => x !== id));
+      renderSaved();
+    };
+  });
+
+  document.getElementById('copy-summary').onclick = () => {
+    const text = data.journals.map((j) => `${j.canonical_title} | ABDC ${j.abdc_rank || NA} | ABS ${j.abs_rating || NA} | Scopus ${j.scopus_status || NA}`).join('\n');
+    navigator.clipboard.writeText(text);
+    alert('Summary copied.');
+  };
+
+  document.getElementById('export-csv').onclick = () => {
+    const rows = [['title', 'issn', 'eissn', 'publisher', 'subject', 'abdc_rank', 'abs_rating', 'scopus_status']].concat(
+      data.journals.map((j) => [j.canonical_title, j.issn || '', j.eissn || '', j.publisher || '', j.subject_area || '', j.abdc_rank || '', j.abs_rating || '', j.scopus_status || ''])
+    );
+    const csv = rows.map((row) => row.map((v) => `"${String(v).replaceAll('"', '""')}"`).join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'shortlist.csv';
+    a.click();
+  };
+}
+
+function renderAbout() {
+  app.innerHTML = pageShell(`
+    <section class="card">
+      <h2>Methodology and limitations</h2>
+      <ol>
+        <li><strong>Matching priority:</strong> ISSN exact match > eISSN exact match > normalized exact title > controlled fuzzy title.</li>
+        <li>Source records remain separate and traceable. Missing values are never inferred.</li>
+        <li>Confidence labels: Exact match, Strong probable match, Uncertain match.</li>
+        <li>Uncertain import records are pushed to admin review queue for manual decision.</li>
+      </ol>
+      <p><strong>Limitation:</strong> Results depend on uploaded verified datasets and their freshness.</p>
+      <p><strong>Critical note:</strong> Final submission decisions must be verified from official source portals.</p>
+    </section>
+  `);
+}
+
+async function renderAdmin() {
+  app.innerHTML = pageShell(`
+    <section class="card">
+      <h2>Admin Dashboard</h2>
+      <label>Admin token</label>
+      <input id="admin-token" value="${localStorage.getItem(adminTokenKey) || ''}" />
+      <button id="save-token">Save token</button>
+      <hr/>
+      <div class="grid two">
+        <div class="card">
+          <h3>Upload source file</h3>
+          <label>Source</label>
+          <select id="upload-source"><option value="abdc">ABDC</option><option value="abs">ABS/AJG</option><option value="scopus">Scopus</option></select>
+          <label>File (CSV or XLSX)</label>
+          <input id="upload-file" type="file" accept=".csv,.xlsx,.xls" />
+          <button id="preview-upload">Preview Upload</button>
+          <div id="preview-out" class="small"></div>
+        </div>
+        <div class="card">
+          <h3>Rollback last import</h3>
+          <label>Source</label>
+          <select id="rollback-source"><option value="abdc">ABDC</option><option value="abs">ABS/AJG</option><option value="scopus">Scopus</option></select>
+          <button id="do-rollback" class="secondary">Rollback</button>
+          <div id="rollback-out" class="small"></div>
+        </div>
+      </div>
+      <div class="grid two">
+        <div class="card"><h3>Upload history</h3><div id="logs">Loading...</div></div>
+        <div class="card"><h3>Rejected/Error rows</h3><button id="download-error-report" class="ghost">Download error report (CSV)</button><div id="queue">Loading...</div></div>
+      </div>
+    </section>
+  `);
+
+  document.getElementById('save-token').onclick = () => {
+    localStorage.setItem(adminTokenKey, document.getElementById('admin-token').value.trim());
+    alert('Token saved.');
+  };
+
+  document.getElementById('preview-upload').onclick = async () => {
+    const token = localStorage.getItem(adminTokenKey) || '';
+    const source = document.getElementById('upload-source').value;
+    const file = document.getElementById('upload-file').files[0];
+    if (!file) return alert('Select file first.');
+
+    const fd = new FormData();
+    fd.append('source', source);
+    fd.append('file', file);
+
+    const resp = await fetch('/api/admin/upload/preview', { method: 'POST', headers: { 'x-admin-token': token }, body: fd });
+    const data = await resp.json();
+    if (!resp.ok) return alert(JSON.stringify(data));
+
+    document.getElementById('preview-out').innerText = `Rows: ${data.total_rows}, duplicates: ${data.duplicate_count}, rejected: ${data.rejected_count}`;
+    if (confirm('Approve this import now?')) {
+      const approved = await apiPost('/api/admin/upload/approve', { stage_id: data.stage_id, uploaded_by: 'admin-web' }, true);
+      alert(`Import done. Processed: ${approved.processed_rows}, Rejected: ${approved.rejected_rows}`);
+      renderAdmin();
+    }
+  };
+
+  document.getElementById('do-rollback').onclick = async () => {
+    try {
+      const output = await apiPost('/api/admin/upload/rollback-last', { source: document.getElementById('rollback-source').value }, true);
+      document.getElementById('rollback-out').innerText = output.message;
+      renderAdmin();
+    } catch (error) {
+      document.getElementById('rollback-out').innerText = String(error);
+    }
+  };
+  document.getElementById('download-error-report').onclick = () => {
+    const token = localStorage.getItem(adminTokenKey) || '';
+    fetch('/api/admin/import-error-report', { headers: { 'x-admin-token': token } })
+      .then((resp) => resp.blob())
+      .then((blob) => {
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = 'import_error_report.csv';
+        a.click();
+      });
+  };
+
+  try {
+    const logs = await apiGet('/api/admin/import-logs');
+    document.getElementById('logs').innerHTML = logs.logs.map((l) => `<div class="card">#${l.id} ${l.source_name} | ${l.status} | processed ${l.processed_rows} | rejected ${l.rejected_rows} | ${l.uploaded_at}</div>`).join('') || 'No logs';
+
+    const queue = await apiGet('/api/admin/review-queue');
+    document.getElementById('queue').innerHTML = queue.queue.map((q) => `<div class="card">#${q.id} ${q.source_name} | ${q.issue_type} | ${q.issue_note}</div>`).join('') || 'No rejected rows';
+  } catch {
+    document.getElementById('logs').innerText = 'Unauthorized. Save admin token first.';
+    document.getElementById('queue').innerText = 'Unauthorized. Save admin token first.';
+  }
+}
+
+async function router() {
+  const hash = location.hash || '#/';
+  if (hash.startsWith('#/results')) return renderResults();
+  if (hash.startsWith('#/journal/')) return renderJournalDetail(hash.split('/')[2]);
+  if (hash.startsWith('#/compare')) return renderCompare();
+  if (hash.startsWith('#/saved')) return renderSaved();
+  if (hash.startsWith('#/about')) return renderAbout();
+  if (hash.startsWith('#/admin')) return renderAdmin();
+  return renderHome();
+}
+
+window.addEventListener('hashchange', router);
+router();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "journal-index-checker",
+  "version": "1.0.0",
+  "description": "Journal Index Checker prototype",
+  "main": "server/server.js",
+  "scripts": {
+    "start": "node server/server.js",
+    "dev": "node server/server.js",
+    "init-db": "node server/initDb.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.21.2",
+    "helmet": "^8.1.0",
+    "multer": "^1.4.5-lts.2",
+    "node-cache": "^5.1.2",
+    "sqlite3": "^5.1.7",
+    "xlsx": "^0.18.5"
+  }
+}

--- a/server/data/demo_seed.json
+++ b/server/data/demo_seed.json
@@ -1,0 +1,122 @@
+{
+  "note": "DEMO ONLY DATA - DO NOT USE FOR FINAL PUBLICATION DECISIONS",
+  "journals": [
+    {
+      "canonical_title": "Journal of Operations Management",
+      "alt_titles": "JOM",
+      "issn": "0272-6963",
+      "eissn": "1873-1317",
+      "publisher": "Elsevier",
+      "subject_area": "Operations Management",
+      "abdc": {
+        "source_title": "Journal of Operations Management",
+        "field_code": "IBUS",
+        "abdc_rank": "A*",
+        "source_version": "DEMO-2026",
+        "source_file_name": "abdc_demo.csv",
+        "source_url": "https://example.org/abdc-demo",
+        "verified_date": "2026-04-01"
+      },
+      "abs": {
+        "source_title": "Journal of Operations Management",
+        "abs_rating": "4",
+        "subject_group": "Operations and Technology Management",
+        "source_version": "DEMO-2026",
+        "source_file_name": "abs_demo.csv",
+        "source_url": "https://example.org/abs-demo",
+        "verified_date": "2026-04-01"
+      },
+      "scopus": {
+        "source_title": "Journal of Operations Management",
+        "scopus_status": "Indexed",
+        "active_or_discontinued": "Active",
+        "coverage_note": "Coverage in demo dataset",
+        "citescore_optional": "13.5",
+        "sjr_optional": "4.11",
+        "snip_optional": "3.2",
+        "source_version": "DEMO-2026",
+        "source_file_name": "scopus_demo.csv",
+        "source_url": "https://example.org/scopus-demo",
+        "verified_date": "2026-04-01"
+      }
+    },
+    {
+      "canonical_title": "International Journal of Production Economics",
+      "alt_titles": "IJPE",
+      "issn": "0925-5273",
+      "eissn": "1873-7579",
+      "publisher": "Elsevier",
+      "subject_area": "Supply Chain",
+      "abdc": {
+        "source_title": "International Journal of Production Economics",
+        "field_code": "OPMN",
+        "abdc_rank": "A",
+        "source_version": "DEMO-2026",
+        "source_file_name": "abdc_demo.csv",
+        "source_url": "https://example.org/abdc-demo",
+        "verified_date": "2026-04-01"
+      },
+      "abs": {
+        "source_title": "International Journal of Production Economics",
+        "abs_rating": "3",
+        "subject_group": "Operations and Technology Management",
+        "source_version": "DEMO-2026",
+        "source_file_name": "abs_demo.csv",
+        "source_url": "https://example.org/abs-demo",
+        "verified_date": "2026-04-01"
+      },
+      "scopus": {
+        "source_title": "International Journal of Production Economics",
+        "scopus_status": "Indexed",
+        "active_or_discontinued": "Active",
+        "coverage_note": "Coverage in demo dataset",
+        "citescore_optional": "12.7",
+        "sjr_optional": "3.01",
+        "snip_optional": "2.8",
+        "source_version": "DEMO-2026",
+        "source_file_name": "scopus_demo.csv",
+        "source_url": "https://example.org/scopus-demo",
+        "verified_date": "2026-04-01"
+      }
+    },
+    {
+      "canonical_title": "Journal of Small Business Management",
+      "alt_titles": "",
+      "issn": "0047-2778",
+      "eissn": "1540-627X",
+      "publisher": "Wiley",
+      "subject_area": "Entrepreneurship",
+      "abdc": {
+        "source_title": "Journal of Small Business Management",
+        "field_code": "ENTR",
+        "abdc_rank": "A",
+        "source_version": "DEMO-2026",
+        "source_file_name": "abdc_demo.csv",
+        "source_url": "https://example.org/abdc-demo",
+        "verified_date": "2026-04-01"
+      },
+      "abs": {
+        "source_title": "Journal of Small Business Management",
+        "abs_rating": "2",
+        "subject_group": "Entrepreneurship and Small Business",
+        "source_version": "DEMO-2026",
+        "source_file_name": "abs_demo.csv",
+        "source_url": "https://example.org/abs-demo",
+        "verified_date": "2026-04-01"
+      },
+      "scopus": {
+        "source_title": "Journal of Small Business Management",
+        "scopus_status": "Indexed",
+        "active_or_discontinued": "Discontinued",
+        "coverage_note": "Demo status only",
+        "citescore_optional": "4.9",
+        "sjr_optional": "1.2",
+        "snip_optional": "1.5",
+        "source_version": "DEMO-2026",
+        "source_file_name": "scopus_demo.csv",
+        "source_url": "https://example.org/scopus-demo",
+        "verified_date": "2026-04-01"
+      }
+    }
+  ]
+}

--- a/server/data/templates/abdc_template.csv
+++ b/server/data/templates/abdc_template.csv
@@ -1,0 +1,2 @@
+source_title,issn,eissn,publisher,field_code,abdc_rank,source_version,source_url,verified_date
+Demo Journal,1234-5678,8765-4321,Demo Publisher,ECON,A,DEMO-2026,https://example.org/source,2026-04-01

--- a/server/data/templates/abs_template.csv
+++ b/server/data/templates/abs_template.csv
@@ -1,0 +1,2 @@
+source_title,issn,eissn,publisher,abs_rating,subject_group,source_version,source_url,verified_date
+Demo Journal,1234-5678,8765-4321,Demo Publisher,3,Operations,DEMO-2026,https://example.org/source,2026-04-01

--- a/server/data/templates/scopus_template.csv
+++ b/server/data/templates/scopus_template.csv
@@ -1,0 +1,2 @@
+source_title,issn,eissn,publisher,scopus_status,active_or_discontinued,coverage_note,citescore_optional,sjr_optional,snip_optional,source_version,source_url,verified_date
+Demo Journal,1234-5678,8765-4321,Demo Publisher,Indexed,Active,Demo note,5.2,1.1,1.3,DEMO-2026,https://example.org/source,2026-04-01

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const dbPath = path.join(__dirname, 'journal_index_checker.sqlite');
+const schemaPath = path.join(__dirname, '..', 'migrations', 'schema.sql');
+
+const db = new sqlite3.Database(dbPath);
+
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function onRun(err) {
+      if (err) reject(err);
+      else resolve(this);
+    });
+  });
+}
+
+function get(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) reject(err);
+      else resolve(row);
+    });
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) reject(err);
+      else resolve(rows);
+    });
+  });
+}
+
+async function initSchema() {
+  const schema = fs.readFileSync(schemaPath, 'utf8');
+  await new Promise((resolve, reject) => {
+    db.exec(schema, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+module.exports = {
+  db,
+  run,
+  get,
+  all,
+  initSchema,
+};

--- a/server/initDb.js
+++ b/server/initDb.js
@@ -1,0 +1,160 @@
+const fs = require('fs');
+const path = require('path');
+const { initSchema, run, get } = require('./db');
+const { normalizeText } = require('./utils/normalize');
+
+async function upsertJournal(journal) {
+  const existing = await get(
+    `SELECT id FROM journals_master
+     WHERE (issn IS NOT NULL AND issn = ?)
+        OR (eissn IS NOT NULL AND eissn = ?)
+        OR normalized_title = ?
+     LIMIT 1`,
+    [journal.issn || null, journal.eissn || null, normalizeText(journal.canonical_title)]
+  );
+
+  const now = new Date().toISOString();
+  if (existing) {
+    await run(
+      `UPDATE journals_master
+       SET canonical_title = ?, normalized_title = ?, alt_titles = ?, issn = ?, eissn = ?,
+           publisher = ?, subject_area = ?, updated_at = ?
+       WHERE id = ?`,
+      [
+        journal.canonical_title,
+        normalizeText(journal.canonical_title),
+        journal.alt_titles || null,
+        journal.issn || null,
+        journal.eissn || null,
+        journal.publisher || null,
+        journal.subject_area || null,
+        now,
+        existing.id,
+      ]
+    );
+    return existing.id;
+  }
+
+  const created = await run(
+    `INSERT INTO journals_master
+     (canonical_title, normalized_title, alt_titles, issn, eissn, publisher, subject_area, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      journal.canonical_title,
+      normalizeText(journal.canonical_title),
+      journal.alt_titles || null,
+      journal.issn || null,
+      journal.eissn || null,
+      journal.publisher || null,
+      journal.subject_area || null,
+      now,
+      now,
+    ]
+  );
+
+  return created.lastID;
+}
+
+async function insertImportLog(sourceName, fileName, processedRows) {
+  const result = await run(
+    `INSERT INTO import_logs (source_name, file_name, uploaded_by, uploaded_at, processed_rows, rejected_rows, status, notes)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [sourceName, fileName, 'seed-script', new Date().toISOString(), processedRows, 0, 'completed', 'DEMO ONLY import']
+  );
+
+  return result.lastID;
+}
+
+async function main() {
+  await initSchema();
+  const seed = JSON.parse(fs.readFileSync(path.join(__dirname, 'data', 'demo_seed.json'), 'utf8'));
+
+  await run('DELETE FROM abdc_entries');
+  await run('DELETE FROM abs_entries');
+  await run('DELETE FROM scopus_entries');
+  await run('DELETE FROM journals_master');
+  await run('DELETE FROM import_logs');
+  await run('DELETE FROM review_queue');
+
+  const abdcLogId = await insertImportLog('abdc', 'abdc_demo.csv', seed.journals.length);
+  const absLogId = await insertImportLog('abs', 'abs_demo.csv', seed.journals.length);
+  const scopusLogId = await insertImportLog('scopus', 'scopus_demo.csv', seed.journals.length);
+
+  for (const journal of seed.journals) {
+    const journalId = await upsertJournal(journal);
+
+    await run(
+      `INSERT INTO abdc_entries
+       (journal_master_id, source_title, issn, eissn, publisher, field_code, abdc_rank, source_version,
+        source_file_name, source_url, verified_date, import_log_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        journalId,
+        journal.abdc.source_title,
+        journal.issn,
+        journal.eissn,
+        journal.publisher,
+        journal.abdc.field_code,
+        journal.abdc.abdc_rank,
+        journal.abdc.source_version,
+        journal.abdc.source_file_name,
+        journal.abdc.source_url,
+        journal.abdc.verified_date,
+        abdcLogId,
+      ]
+    );
+
+    await run(
+      `INSERT INTO abs_entries
+       (journal_master_id, source_title, issn, eissn, publisher, abs_rating, subject_group, source_version,
+        source_file_name, source_url, verified_date, import_log_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        journalId,
+        journal.abs.source_title,
+        journal.issn,
+        journal.eissn,
+        journal.publisher,
+        journal.abs.abs_rating,
+        journal.abs.subject_group,
+        journal.abs.source_version,
+        journal.abs.source_file_name,
+        journal.abs.source_url,
+        journal.abs.verified_date,
+        absLogId,
+      ]
+    );
+
+    await run(
+      `INSERT INTO scopus_entries
+       (journal_master_id, source_title, issn, eissn, publisher, scopus_status, active_or_discontinued, coverage_note,
+        citescore_optional, sjr_optional, snip_optional, source_version, source_file_name, source_url, verified_date, import_log_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        journalId,
+        journal.scopus.source_title,
+        journal.issn,
+        journal.eissn,
+        journal.publisher,
+        journal.scopus.scopus_status,
+        journal.scopus.active_or_discontinued,
+        journal.scopus.coverage_note,
+        journal.scopus.citescore_optional,
+        journal.scopus.sjr_optional,
+        journal.scopus.snip_optional,
+        journal.scopus.source_version,
+        journal.scopus.source_file_name,
+        journal.scopus.source_url,
+        journal.scopus.verified_date,
+        scopusLogId,
+      ]
+    );
+  }
+
+  console.log('Database initialized with DEMO ONLY seed data.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/server/migrations/schema.sql
+++ b/server/migrations/schema.sql
@@ -1,0 +1,105 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS journals_master (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  canonical_title TEXT NOT NULL,
+  normalized_title TEXT NOT NULL,
+  alt_titles TEXT,
+  issn TEXT,
+  eissn TEXT,
+  publisher TEXT,
+  subject_area TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_journals_master_issn ON journals_master(issn);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_journals_master_eissn ON journals_master(eissn);
+CREATE INDEX IF NOT EXISTS idx_journals_master_title ON journals_master(normalized_title);
+CREATE INDEX IF NOT EXISTS idx_journals_master_publisher ON journals_master(publisher);
+CREATE INDEX IF NOT EXISTS idx_journals_master_subject_area ON journals_master(subject_area);
+
+CREATE TABLE IF NOT EXISTS abdc_entries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  journal_master_id INTEGER,
+  source_title TEXT NOT NULL,
+  issn TEXT,
+  eissn TEXT,
+  publisher TEXT,
+  field_code TEXT,
+  abdc_rank TEXT,
+  source_version TEXT,
+  source_file_name TEXT,
+  source_url TEXT,
+  verified_date TEXT,
+  import_log_id INTEGER,
+  FOREIGN KEY (journal_master_id) REFERENCES journals_master(id),
+  FOREIGN KEY (import_log_id) REFERENCES import_logs(id)
+);
+
+CREATE TABLE IF NOT EXISTS abs_entries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  journal_master_id INTEGER,
+  source_title TEXT NOT NULL,
+  issn TEXT,
+  eissn TEXT,
+  publisher TEXT,
+  abs_rating TEXT,
+  subject_group TEXT,
+  source_version TEXT,
+  source_file_name TEXT,
+  source_url TEXT,
+  verified_date TEXT,
+  import_log_id INTEGER,
+  FOREIGN KEY (journal_master_id) REFERENCES journals_master(id),
+  FOREIGN KEY (import_log_id) REFERENCES import_logs(id)
+);
+
+CREATE TABLE IF NOT EXISTS scopus_entries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  journal_master_id INTEGER,
+  source_title TEXT NOT NULL,
+  issn TEXT,
+  eissn TEXT,
+  publisher TEXT,
+  scopus_status TEXT,
+  active_or_discontinued TEXT,
+  coverage_note TEXT,
+  citescore_optional TEXT,
+  sjr_optional TEXT,
+  snip_optional TEXT,
+  source_version TEXT,
+  source_file_name TEXT,
+  source_url TEXT,
+  verified_date TEXT,
+  import_log_id INTEGER,
+  FOREIGN KEY (journal_master_id) REFERENCES journals_master(id),
+  FOREIGN KEY (import_log_id) REFERENCES import_logs(id)
+);
+
+CREATE TABLE IF NOT EXISTS import_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source_name TEXT NOT NULL,
+  file_name TEXT NOT NULL,
+  uploaded_by TEXT NOT NULL,
+  uploaded_at TEXT NOT NULL,
+  processed_rows INTEGER NOT NULL DEFAULT 0,
+  rejected_rows INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL,
+  notes TEXT
+);
+
+CREATE TABLE IF NOT EXISTS review_queue (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source_name TEXT NOT NULL,
+  record_reference TEXT NOT NULL,
+  issue_type TEXT NOT NULL,
+  issue_note TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  reviewed_by TEXT,
+  reviewed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_abdc_journal_id ON abdc_entries(journal_master_id);
+CREATE INDEX IF NOT EXISTS idx_abs_journal_id ON abs_entries(journal_master_id);
+CREATE INDEX IF NOT EXISTS idx_scopus_journal_id ON scopus_entries(journal_master_id);

--- a/server/server.js
+++ b/server/server.js
@@ -1,31 +1,624 @@
-const http = require('http');
+const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+const multer = require('multer');
 const fs = require('fs');
-const url = require('url');
 const path = require('path');
+const xlsx = require('xlsx');
+const NodeCache = require('node-cache');
+const { initSchema, run, get, all } = require('./db');
+const { normalizeText, normalizeIssn, similarityScore } = require('./utils/normalize');
 
 const PORT = process.env.PORT || 3001;
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN || 'change-me-admin-token';
+const upload = multer({ dest: path.join(__dirname, 'uploads') });
+const searchCache = new NodeCache({ stdTTL: 120 });
 
-function readData(file) {
-  return JSON.parse(fs.readFileSync(path.join(__dirname, 'data', file)));
-}
+const app = express();
+app.use(cors());
+app.use(helmet());
+app.use(express.json({ limit: '5mb' }));
+app.use(express.static(path.join(__dirname, '..', 'client')));
 
-function handleRequest(req, res) {
-  const parsedUrl = url.parse(req.url, true);
-  if (parsedUrl.pathname === '/api/abs') {
-    const data = readData('abs.json');
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(data));
-  } else if (parsedUrl.pathname === '/api/abdc') {
-    const data = readData('abdc.json');
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(data));
-  } else {
-    res.writeHead(404);
-    res.end('Not found');
+const SOURCE_CONFIG = {
+  abdc: {
+    table: 'abdc_entries',
+    required: ['source_title', 'abdc_rank'],
+    optional: ['issn', 'eissn', 'publisher', 'field_code', 'source_version', 'source_file_name', 'source_url', 'verified_date'],
+  },
+  abs: {
+    table: 'abs_entries',
+    required: ['source_title', 'abs_rating'],
+    optional: ['issn', 'eissn', 'publisher', 'subject_group', 'source_version', 'source_file_name', 'source_url', 'verified_date'],
+  },
+  scopus: {
+    table: 'scopus_entries',
+    required: ['source_title', 'scopus_status'],
+    optional: ['issn', 'eissn', 'publisher', 'active_or_discontinued', 'coverage_note', 'citescore_optional', 'sjr_optional', 'snip_optional', 'source_version', 'source_file_name', 'source_url', 'verified_date'],
+  },
+};
+
+const MISSING_SENTENCE = 'Not found in uploaded verified source data.';
+
+function adminOnly(req, res, next) {
+  if (req.headers['x-admin-token'] !== ADMIN_TOKEN) {
+    return res.status(401).json({ message: 'Unauthorized admin request.' });
   }
+  return next();
 }
 
-const server = http.createServer(handleRequest);
-server.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
+async function hydrateJournal(journal) {
+  const [abdc, abs, scopus] = await Promise.all([
+    get('SELECT * FROM abdc_entries WHERE journal_master_id = ? ORDER BY id DESC LIMIT 1', [journal.id]),
+    get('SELECT * FROM abs_entries WHERE journal_master_id = ? ORDER BY id DESC LIMIT 1', [journal.id]),
+    get('SELECT * FROM scopus_entries WHERE journal_master_id = ? ORDER BY id DESC LIMIT 1', [journal.id]),
+  ]);
+
+  return {
+    ...journal,
+    abdc_rank: abdc?.abdc_rank || null,
+    abs_rating: abs?.abs_rating || null,
+    scopus_status: scopus?.scopus_status || null,
+    active_or_discontinued: scopus?.active_or_discontinued || null,
+    source_last_updated: {
+      abdc: abdc?.verified_date || null,
+      abs: abs?.verified_date || null,
+      scopus: scopus?.verified_date || null,
+    },
+    source_links: {
+      abdc: abdc?.source_url || null,
+      abs: abs?.source_url || null,
+      scopus: scopus?.source_url || null,
+    },
+  };
+}
+
+function computeConfidence(journal, q) {
+  // Confidence is strictly rule-based to keep results auditable.
+  const query = normalizeText(q);
+  const issnQuery = normalizeIssn(q);
+  if (!query && !issnQuery) return { label: 'Exact match', score: 1 };
+
+  if (journal.issn && normalizeIssn(journal.issn) === issnQuery) return { label: 'Exact match', score: 1 };
+  if (journal.eissn && normalizeIssn(journal.eissn) === issnQuery) return { label: 'Exact match', score: 0.99 };
+  if (normalizeText(journal.canonical_title) === query) return { label: 'Exact match', score: 0.98 };
+
+  const score = Math.max(
+    similarityScore(journal.canonical_title, query),
+    similarityScore(journal.alt_titles || '', query),
+    similarityScore(journal.publisher || '', query),
+    similarityScore(journal.subject_area || '', query)
+  );
+
+  if (score >= 0.82) return { label: 'Strong probable match', score };
+  return { label: 'Uncertain match', score };
+}
+
+function queryIssnCandidates(q = '') {
+  return String(q)
+    .split(/[\s,;|]+/)
+    .map((token) => normalizeIssn(token))
+    .filter(Boolean);
+}
+
+function matchesJournal(journal, q) {
+  if (!q) return true;
+  const query = normalizeText(q);
+  const issnQuery = normalizeIssn(q);
+  const issnCandidates = queryIssnCandidates(q);
+  const fields = [journal.canonical_title, journal.alt_titles, journal.publisher, journal.subject_area]
+    .map((item) => normalizeText(item || ''));
+  const journalIssn = normalizeIssn(journal.issn || '');
+  const journalEIssn = normalizeIssn(journal.eissn || '');
+  return (
+    fields.some((field) => field.includes(query)) ||
+    journalIssn === issnQuery ||
+    journalEIssn === issnQuery ||
+    issnCandidates.includes(journalIssn) ||
+    issnCandidates.includes(journalEIssn) ||
+    similarityScore(journal.canonical_title, query) >= 0.72
+  );
+}
+
+function applyFilters(rows, filters) {
+  return rows.filter((row) => {
+    if (filters.abdc_rank && row.abdc_rank !== filters.abdc_rank) return false;
+    if (filters.abs_rating && row.abs_rating !== filters.abs_rating) return false;
+    if (filters.scopus_status && (row.scopus_status || 'Not indexed') !== filters.scopus_status) return false;
+    if (filters.active_or_discontinued && (row.active_or_discontinued || 'Not indexed') !== filters.active_or_discontinued) return false;
+    if (filters.subject_area && !normalizeText(row.subject_area || '').includes(normalizeText(filters.subject_area))) return false;
+    if (filters.publisher && !normalizeText(row.publisher || '').includes(normalizeText(filters.publisher))) return false;
+    if (filters.exact_only === 'true' && row.match_confidence !== 'Exact match') return false;
+    if (filters.show_similar === 'false' && row.match_confidence === 'Uncertain match') return false;
+    return true;
+  });
+}
+
+function sortRows(rows, sortBy) {
+  const rankScore = { 'A*': 4, A: 3, B: 2, C: 1 };
+  return rows.sort((a, b) => {
+    // Always keep exact matches above fuzzy/probable matches.
+    if ((a.match_confidence === 'Exact match') !== (b.match_confidence === 'Exact match')) {
+      return a.match_confidence === 'Exact match' ? -1 : 1;
+    }
+    if (sortBy === 'title') return (a.canonical_title || '').localeCompare(b.canonical_title || '');
+    if (sortBy === 'abdc_rank') return (rankScore[b.abdc_rank] || -1) - (rankScore[a.abdc_rank] || -1);
+    if (sortBy === 'abs_rating') return Number(b.abs_rating || 0) - Number(a.abs_rating || 0);
+    if (sortBy === 'publisher') return (a.publisher || '').localeCompare(b.publisher || '');
+    return (b.match_score || 0) - (a.match_score || 0);
+  });
+}
+
+function suggestionForQuery(rows, q) {
+  if (!q || !rows.length) return null;
+  const normalized = normalizeText(q);
+  const exactByTitle = rows.find((row) => normalizeText(row.canonical_title) === normalized);
+  if (exactByTitle) return null;
+
+  const fuzzyCandidate = rows
+    .map((row) => ({
+      title: row.canonical_title,
+      score: similarityScore(row.canonical_title, q),
+    }))
+    .sort((a, b) => b.score - a.score)[0];
+
+  if (fuzzyCandidate && fuzzyCandidate.score >= 0.76) {
+    return {
+      text: `Did you mean "${fuzzyCandidate.title}"?`,
+      suggestion: fuzzyCandidate.title,
+      score: Number(fuzzyCandidate.score.toFixed(3)),
+    };
+  }
+  return null;
+}
+
+async function resolveOrCreateJournal({ sourceTitle, issn, eissn, publisher, subjectArea }) {
+  const normalizedTitle = normalizeText(sourceTitle);
+  const existing = await get(
+    `SELECT * FROM journals_master
+      WHERE (issn IS NOT NULL AND issn = ?)
+         OR (eissn IS NOT NULL AND eissn = ?)
+         OR normalized_title = ?
+      LIMIT 1`,
+    [issn || null, eissn || null, normalizedTitle]
+  );
+
+  const now = new Date().toISOString();
+  if (existing) {
+    await run(
+      `UPDATE journals_master
+         SET publisher = COALESCE(?, publisher),
+             subject_area = COALESCE(?, subject_area),
+             alt_titles = COALESCE(alt_titles, ''),
+             updated_at = ?
+       WHERE id = ?`,
+      [publisher || null, subjectArea || null, now, existing.id]
+    );
+    return existing.id;
+  }
+
+  const created = await run(
+    `INSERT INTO journals_master
+      (canonical_title, normalized_title, alt_titles, issn, eissn, publisher, subject_area, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [sourceTitle, normalizedTitle, null, issn || null, eissn || null, publisher || null, subjectArea || null, now, now]
+  );
+
+  return created.lastID;
+}
+
+function parseFile(filePath) {
+  const workbook = xlsx.readFile(filePath);
+  const firstSheet = workbook.SheetNames[0];
+  return xlsx.utils.sheet_to_json(workbook.Sheets[firstSheet], { defval: '' });
+}
+
+function normalizeHeaderKey(key) {
+  return normalizeText(key).replace(/\s+/g, '_');
+}
+
+function autoMapColumns(row) {
+  const keys = Object.keys(row);
+  const mapped = {};
+  keys.forEach((key) => {
+    mapped[normalizeHeaderKey(key)] = key;
+  });
+  return mapped;
+}
+
+function extractValue(row, map, preferredKeys) {
+  for (const key of preferredKeys) {
+    const sourceKey = map[key];
+    if (sourceKey && row[sourceKey] !== undefined && String(row[sourceKey]).trim() !== '') {
+      return String(row[sourceKey]).trim();
+    }
+  }
+  return null;
+}
+
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok', service: 'Journal Index Checker API' });
 });
+
+app.get('/api/search', async (req, res) => {
+  const cacheKey = JSON.stringify(req.query);
+  const cached = searchCache.get(cacheKey);
+  if (cached) return res.json(cached);
+
+  const rows = await all('SELECT * FROM journals_master');
+  const hydrated = await Promise.all(rows.map(async (row) => {
+    const enriched = await hydrateJournal(row);
+    const confidence = computeConfidence(enriched, req.query.q || '');
+    return {
+      ...enriched,
+      match_confidence: confidence.label,
+      match_score: confidence.score,
+    };
+  }));
+
+  const searched = hydrated.filter((row) => matchesJournal(row, req.query.q || ''));
+  const filtered = applyFilters(searched, req.query);
+  const sorted = sortRows(filtered, req.query.sort_by || 'relevance');
+
+  const didYouMean = suggestionForQuery(hydrated, req.query.q || '');
+
+  const payload = {
+    query: req.query.q || '',
+    did_you_mean: didYouMean,
+    total: sorted.length,
+    results: sorted.map((item) => ({
+      ...item,
+      abdc_rank: item.abdc_rank || MISSING_SENTENCE,
+      abs_rating: item.abs_rating || MISSING_SENTENCE,
+      scopus_status: item.scopus_status || MISSING_SENTENCE,
+      active_or_discontinued: item.active_or_discontinued || MISSING_SENTENCE,
+    })),
+  };
+
+  searchCache.set(cacheKey, payload);
+  res.json(payload);
+});
+
+app.get('/api/journals/:id', async (req, res) => {
+  const journal = await get('SELECT * FROM journals_master WHERE id = ?', [req.params.id]);
+  if (!journal) return res.status(404).json({ message: 'Journal not found.' });
+
+  const [abdcEntries, absEntries, scopusEntries] = await Promise.all([
+    all('SELECT * FROM abdc_entries WHERE journal_master_id = ? ORDER BY id DESC', [journal.id]),
+    all('SELECT * FROM abs_entries WHERE journal_master_id = ? ORDER BY id DESC', [journal.id]),
+    all('SELECT * FROM scopus_entries WHERE journal_master_id = ? ORDER BY id DESC', [journal.id]),
+  ]);
+
+  const payload = {
+    ...journal,
+    disclaimer: 'Guidance only. Always verify using official source sites before submission decisions.',
+    data_warning: (!abdcEntries.length || !absEntries.length || !scopusEntries.length)
+      ? 'Incomplete record: one or more source datasets are missing for this journal.'
+      : null,
+    match_note: req.query.match_note || 'Exact and probable matching is based on ISSN/eISSN/title logic.',
+    sources: {
+      abdc: abdcEntries.length ? abdcEntries : [{ note: 'Not available in verified source data.' }],
+      abs: absEntries.length ? absEntries : [{ note: 'Not available in verified source data.' }],
+      scopus: scopusEntries.length ? scopusEntries : [{ note: 'Not available in verified source data.' }],
+    },
+  };
+
+  res.json(payload);
+});
+
+app.get('/api/compare', async (req, res) => {
+  const ids = (req.query.ids || '')
+    .split(',')
+    .map((id) => Number(id.trim()))
+    .filter((id) => Number.isInteger(id))
+    .slice(0, 4);
+
+  if (ids.length < 2) {
+    return res.status(400).json({ message: 'Provide between 2 and 4 journal IDs.' });
+  }
+
+  const journals = [];
+  for (const id of ids) {
+    const journal = await get('SELECT * FROM journals_master WHERE id = ?', [id]);
+    if (journal) journals.push(await hydrateJournal(journal));
+  }
+
+  res.json({ journals });
+});
+
+app.post('/api/assistant/query', async (req, res) => {
+  const text = normalizeText(req.body.query || '');
+  if (!text) return res.status(400).json({ message: 'Query is required.' });
+
+  const filters = {};
+  const rankMatch = text.match(/abdc\s+(a\*|a|b|c)/i);
+  if (rankMatch) filters.abdc_rank = rankMatch[1].toUpperCase();
+  const absMatch = text.match(/abs\s+(\d)/i);
+  if (absMatch) filters.abs_rating = absMatch[1];
+  if (text.includes('scopus')) filters.scopus_status = 'Indexed';
+
+  const rows = await all('SELECT * FROM journals_master');
+  const hydrated = await Promise.all(rows.map(hydrateJournal));
+  const result = applyFilters(
+    hydrated.map((row) => ({ ...row, scopus_status: row.scopus_status || 'Not indexed' })),
+    filters
+  ).slice(0, 20);
+
+  if (!result.length) {
+    return res.json({
+      answer: 'Not available in uploaded verified source data.',
+      filters,
+      results: [],
+    });
+  }
+
+  return res.json({
+    answer: `Found ${result.length} journal(s) based on uploaded verified source data.`,
+    filters,
+    results: result,
+  });
+});
+
+app.get('/api/admin/import-logs', adminOnly, async (_req, res) => {
+  const logs = await all('SELECT * FROM import_logs ORDER BY id DESC LIMIT 100');
+  res.json({ logs });
+});
+
+app.get('/api/admin/review-queue', adminOnly, async (_req, res) => {
+  const queue = await all('SELECT * FROM review_queue ORDER BY id DESC LIMIT 100');
+  res.json({ queue });
+});
+
+app.get('/api/admin/import-error-report', adminOnly, async (_req, res) => {
+  const queue = await all(
+    `SELECT source_name, record_reference, issue_type, issue_note, status
+     FROM review_queue
+     ORDER BY id DESC`
+  );
+  const csvRows = [
+    'source_name,record_reference,issue_type,issue_note,status',
+    ...queue.map((row) => [
+      row.source_name,
+      row.record_reference,
+      row.issue_type,
+      `"${String(row.issue_note || '').replaceAll('"', '""')}"`,
+      row.status,
+    ].join(',')),
+  ];
+  res.setHeader('Content-Type', 'text/csv');
+  res.setHeader('Content-Disposition', 'attachment; filename=\"import_error_report.csv\"');
+  res.send(csvRows.join('\n'));
+});
+
+app.post('/api/admin/upload/preview', adminOnly, upload.single('file'), async (req, res) => {
+  try {
+    const source = normalizeText(req.body.source || '');
+    if (!SOURCE_CONFIG[source]) return res.status(400).json({ message: 'Unsupported source.' });
+
+    const rows = parseFile(req.file.path);
+    const mappedHeaders = rows[0] ? autoMapColumns(rows[0]) : {};
+
+    const rejections = [];
+    const previews = rows.slice(0, 20);
+    const duplicates = [];
+    const seen = new Set();
+
+    rows.forEach((row, idx) => {
+      const title = extractValue(row, mappedHeaders, ['source_title', 'journal_title', 'title']);
+      const issn = normalizeIssn(extractValue(row, mappedHeaders, ['issn']) || '');
+      const eissn = normalizeIssn(extractValue(row, mappedHeaders, ['eissn', 'e_issn']) || '');
+      const rowKey = `${title}|${issn}|${eissn}`;
+
+      if (!title) {
+        rejections.push({ row: idx + 1, reason: 'Missing title' });
+      }
+      if (seen.has(rowKey)) {
+        duplicates.push({ row: idx + 1, rowKey });
+      }
+      seen.add(rowKey);
+    });
+
+    const stageId = `stage_${Date.now()}`;
+    const stagePath = path.join(__dirname, 'tmp', `${stageId}.json`);
+    fs.writeFileSync(stagePath, JSON.stringify({ source, rows, mappedHeaders, rejections, duplicates, fileName: req.file.originalname }));
+
+    fs.unlinkSync(req.file.path);
+
+    res.json({
+      stage_id: stageId,
+      source,
+      file_name: req.file.originalname,
+      total_rows: rows.length,
+      preview_rows: previews,
+      mapped_headers: mappedHeaders,
+      required_columns: SOURCE_CONFIG[source].required,
+      duplicate_count: duplicates.length,
+      rejected_count: rejections.length,
+      validation_status: rejections.length ? 'needs-review' : 'ready',
+    });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+app.post('/api/admin/upload/approve', adminOnly, async (req, res) => {
+  const stageId = req.body.stage_id;
+  const stagedPath = path.join(__dirname, 'tmp', `${stageId}.json`);
+  if (!fs.existsSync(stagedPath)) return res.status(404).json({ message: 'Stage not found.' });
+
+  const staged = JSON.parse(fs.readFileSync(stagedPath, 'utf8'));
+  const config = SOURCE_CONFIG[staged.source];
+  const mapping = req.body.column_map || staged.mappedHeaders;
+  let processedRows = 0;
+  let rejectedRows = 0;
+
+  const log = await run(
+    `INSERT INTO import_logs (source_name, file_name, uploaded_by, uploaded_at, processed_rows, rejected_rows, status, notes)
+     VALUES (?, ?, ?, ?, 0, 0, 'processing', ?)` ,
+    [staged.source, staged.fileName, req.body.uploaded_by || 'admin', new Date().toISOString(), 'Import started from admin panel']
+  );
+
+  // Row-by-row processing keeps each rejected record traceable in review_queue.
+  for (const [index, row] of staged.rows.entries()) {
+    const sourceTitle = extractValue(row, mapping, ['source_title', 'journal_title', 'title']);
+    if (!sourceTitle) {
+      rejectedRows += 1;
+      await run(
+        `INSERT INTO review_queue (source_name, record_reference, issue_type, issue_note, status)
+         VALUES (?, ?, ?, ?, 'pending')`,
+        [staged.source, `row-${index + 1}`, 'missing_title', 'Title missing in imported row']
+      );
+      continue;
+    }
+
+    const issn = normalizeIssn(extractValue(row, mapping, ['issn']) || '');
+    const eissn = normalizeIssn(extractValue(row, mapping, ['eissn', 'e_issn']) || '');
+    const publisher = extractValue(row, mapping, ['publisher']);
+    const subjectArea = extractValue(row, mapping, ['subject_area', 'subject_group']);
+    const journalId = await resolveOrCreateJournal({ sourceTitle, issn, eissn, publisher, subjectArea });
+
+    if (staged.source === 'abdc') {
+      await run(
+        `INSERT INTO abdc_entries
+         (journal_master_id, source_title, issn, eissn, publisher, field_code, abdc_rank, source_version, source_file_name, source_url, verified_date, import_log_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          journalId,
+          sourceTitle,
+          issn || null,
+          eissn || null,
+          publisher || null,
+          extractValue(row, mapping, ['field_code', 'field']) || null,
+          extractValue(row, mapping, ['abdc_rank', 'rank']) || null,
+          extractValue(row, mapping, ['source_version']) || 'unknown',
+          staged.fileName,
+          extractValue(row, mapping, ['source_url']) || null,
+          extractValue(row, mapping, ['verified_date']) || null,
+          log.lastID,
+        ]
+      );
+    }
+
+    if (staged.source === 'abs') {
+      await run(
+        `INSERT INTO abs_entries
+         (journal_master_id, source_title, issn, eissn, publisher, abs_rating, subject_group, source_version, source_file_name, source_url, verified_date, import_log_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          journalId,
+          sourceTitle,
+          issn || null,
+          eissn || null,
+          publisher || null,
+          extractValue(row, mapping, ['abs_rating', 'rating']) || null,
+          extractValue(row, mapping, ['subject_group']) || null,
+          extractValue(row, mapping, ['source_version']) || 'unknown',
+          staged.fileName,
+          extractValue(row, mapping, ['source_url']) || null,
+          extractValue(row, mapping, ['verified_date']) || null,
+          log.lastID,
+        ]
+      );
+    }
+
+    if (staged.source === 'scopus') {
+      await run(
+        `INSERT INTO scopus_entries
+         (journal_master_id, source_title, issn, eissn, publisher, scopus_status, active_or_discontinued, coverage_note,
+          citescore_optional, sjr_optional, snip_optional, source_version, source_file_name, source_url, verified_date, import_log_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          journalId,
+          sourceTitle,
+          issn || null,
+          eissn || null,
+          publisher || null,
+          extractValue(row, mapping, ['scopus_status', 'status']) || null,
+          extractValue(row, mapping, ['active_or_discontinued', 'active_status']) || null,
+          extractValue(row, mapping, ['coverage_note']) || null,
+          extractValue(row, mapping, ['citescore_optional', 'citescore']) || null,
+          extractValue(row, mapping, ['sjr_optional', 'sjr']) || null,
+          extractValue(row, mapping, ['snip_optional', 'snip']) || null,
+          extractValue(row, mapping, ['source_version']) || 'unknown',
+          staged.fileName,
+          extractValue(row, mapping, ['source_url']) || null,
+          extractValue(row, mapping, ['verified_date']) || null,
+          log.lastID,
+        ]
+      );
+    }
+
+    processedRows += 1;
+  }
+
+  await run(
+    'UPDATE import_logs SET processed_rows = ?, rejected_rows = ?, status = ? WHERE id = ?',
+    [processedRows, rejectedRows, 'completed', log.lastID]
+  );
+
+  fs.unlinkSync(stagedPath);
+  searchCache.flushAll();
+
+  res.json({ message: 'Import approved.', processed_rows: processedRows, rejected_rows: rejectedRows, import_log_id: log.lastID });
+});
+
+app.post('/api/admin/upload/rollback-last', adminOnly, async (req, res) => {
+  const source = normalizeText(req.body.source || '');
+  if (!SOURCE_CONFIG[source]) return res.status(400).json({ message: 'Unsupported source.' });
+
+  const latest = await get(
+    `SELECT * FROM import_logs
+     WHERE source_name = ? AND status = 'completed'
+     ORDER BY id DESC LIMIT 1`,
+    [source]
+  );
+
+  if (!latest) return res.status(404).json({ message: 'No completed import found for source.' });
+
+  const table = SOURCE_CONFIG[source].table;
+  await run(`DELETE FROM ${table} WHERE import_log_id = ?`, [latest.id]);
+  await run('UPDATE import_logs SET status = ?, notes = COALESCE(notes, "") || ? WHERE id = ?', ['rolled_back', ' | Rolled back by admin', latest.id]);
+
+  searchCache.flushAll();
+  res.json({ message: 'Rolled back last import.', import_log_id: latest.id, source });
+});
+
+app.get('/api/admin/templates/:source', adminOnly, (req, res) => {
+  const source = normalizeText(req.params.source);
+  if (!['abdc', 'abs', 'scopus'].includes(source)) {
+    return res.status(400).json({ message: 'Invalid source template.' });
+  }
+
+  const filePath = path.join(__dirname, 'data', 'templates', `${source}_template.csv`);
+  if (!fs.existsSync(filePath)) {
+    return res.status(404).json({ message: 'Template not found.' });
+  }
+
+  res.download(filePath);
+});
+
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'client', 'index.html'));
+});
+
+initSchema()
+  .then(async () => {
+    const seedCheck = await get('SELECT COUNT(*) AS count FROM journals_master');
+    if (!seedCheck || seedCheck.count === 0) {
+      // Lazy init of demo data if the DB is empty.
+      await new Promise((resolve, reject) => {
+        const script = require('child_process').fork(path.join(__dirname, 'initDb.js'));
+        script.on('exit', (code) => (code === 0 ? resolve() : reject(new Error('Seed initialization failed'))));
+      });
+    }
+
+    app.listen(PORT, () => {
+      console.log(`Journal Index Checker running at http://localhost:${PORT}`);
+    });
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+
+module.exports = app;

--- a/server/utils/normalize.js
+++ b/server/utils/normalize.js
@@ -1,0 +1,50 @@
+function normalizeText(value = '') {
+  return String(value)
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeIssn(value = '') {
+  return String(value).toUpperCase().replace(/[^0-9X]/g, '');
+}
+
+function levenshteinDistance(a, b) {
+  const left = normalizeText(a);
+  const right = normalizeText(b);
+  if (!left.length) return right.length;
+  if (!right.length) return left.length;
+
+  const matrix = Array.from({ length: left.length + 1 }, () => Array(right.length + 1).fill(0));
+  for (let i = 0; i <= left.length; i += 1) matrix[i][0] = i;
+  for (let j = 0; j <= right.length; j += 1) matrix[0][j] = j;
+
+  for (let i = 1; i <= left.length; i += 1) {
+    for (let j = 1; j <= right.length; j += 1) {
+      const cost = left[i - 1] === right[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost
+      );
+    }
+  }
+
+  return matrix[left.length][right.length];
+}
+
+function similarityScore(a, b) {
+  const left = normalizeText(a);
+  const right = normalizeText(b);
+  if (!left && !right) return 1;
+  const maxLen = Math.max(left.length, right.length) || 1;
+  return 1 - levenshteinDistance(left, right) / maxLen;
+}
+
+module.exports = {
+  normalizeText,
+  normalizeIssn,
+  similarityScore,
+};


### PR DESCRIPTION
### Motivation
- Provide a build-ready responsive website prototype that lets researchers check whether journals appear in ABDC, ABS/AJG, and Scopus from a single, auditable source. 
- Enforce an "accuracy-first" policy where missing values are never inferred and ambiguous rows are routed for human review. 
- Support maintainable local deployments with a lightweight tech stack (Node/Express + SQLite) and an admin import/rollback workflow for reproducible dataset updates.

### Description
- Implement a full backend API in `server/server.js` with endpoints for `GET /api/search`, `GET /api/journals/:id`, `GET /api/compare`, an assistant endpoint `POST /api/assistant/query`, and admin endpoints for previewing, approving, and rolling back imports, plus logs and templates; the server uses `sqlite3`, `multer`, `xlsx`, and an in-memory cache via `node-cache`.
- Add a relational schema in `server/migrations/schema.sql`, a DB helper in `server/db/index.js`, a seed/import script `server/initDb.js`, demo seed data `server/data/demo_seed.json`, and CSV/XLSX templates for each source under `server/data/templates/`.
- Replace the previous client with a vanilla JS single-page app under `client/` including `client/index.html`, `client/main.js` (routing, search UI, results, journal detail, compare, saved shortlist, admin UI), and `client/assets/styles.css` for responsive styling.
- Add normalization and fuzzy matching utilities in `server/utils/normalize.js`, matching rules and confidence labels (ISSN/eISSN > normalized exact title > controlled fuzzy match), and robust import logic that logs rejects to `review_queue` and writes import logs to `import_logs`; also include `package.json` for start/init scripts.

### Testing
- No automated tests were added or executed as part of this change; unit and integration test suites are not included in this prototype.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a0c739c0832bb90c9ae4bb69d9b1)